### PR TITLE
bugfix/travis jdk version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-    - oraclejdk8
+    - openjdk8
 sudo: false
 before_install:
     - chmod +x ./gradlew


### PR DESCRIPTION
- Updated `travis.yml` to use `openjdk8`.